### PR TITLE
fix: implement H5 fix

### DIFF
--- a/HazelNet-Web/Features/Deck/Components/DeckView.razor
+++ b/HazelNet-Web/Features/Deck/Components/DeckView.razor
@@ -86,7 +86,7 @@
                                     <MudMenuItem Icon="@Icons.Material.Filled.Delete"
                                                  IconColor="Color.Error"
                                                  OnClick="@DeleteDeck">
-                                        <MudText Color="Color.Error">Delete</MudText>
+                                        <MudText Color="Color.Error">Delete "@Deck.Name"</MudText>
                                     </MudMenuItem>
                                 </MudMenu>
 


### PR DESCRIPTION
simply injected the name of the deck on the "Delete" button to address the H5 issue pointed out by the evaluators. 